### PR TITLE
json response on successful deliver_message op

### DIFF
--- a/lib/channel_sender_ex/transport/rest/rest_controller.ex
+++ b/lib/channel_sender_ex/transport/rest/rest_controller.ex
@@ -56,7 +56,9 @@ defmodule ChannelSenderEx.Transport.Rest.RestController do
     _result =
       PubSubCore.deliver_to_channel(channel_ref, ProtocolMessage.to_protocol_message(message))
 
-    send_resp(conn, 202, "Ok")
+    conn
+    |> put_resp_header("Content-Type", "application/json")
+    |> send_resp(202, Jason.encode!(%{result: "Ok"}))
   end
 
   defp deliver_message(conn), do: invalid_body(conn)

--- a/test/channel_sender_ex/transport/rest/rest_controller_test.exs
+++ b/test/channel_sender_ex/transport/rest/rest_controller_test.exs
@@ -61,11 +61,12 @@ defmodule ChannelSenderEx.Transport.Rest.RestControllerTest do
         event_name: "event_name"
       })
 
-    {status, _headers, body} =
+    {status, headers, body} =
       request(:post, "/ext/channel/deliver_message", [{"content-type", "application/json"}], body)
 
     assert 202 == status
-    assert "Ok" == body
+    assert %{"result" => "Ok"} = Jason.decode!(body)
+    assert Enum.member?(headers, {"Content-Type", "application/json"})
   end
 
   test "Should fail on invalid body" do


### PR DESCRIPTION
## Description
Feature #4 - gives a json response on successful call to deliver_message rest operation.

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/async-dataflow-channel-sender/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [ ] the version of the mix.exs was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
